### PR TITLE
Add `remove_root_access` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+
+### Added
+
+* A new `remove_root_access` input to remove sudo access from the ubuntu user.
+
+### Fixed
+
+* The instructions for modifying ssh_config files to use the bastion are now more complete.
+
 ## [0.1.0]
 
 Initial commit / release.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Ubuntu 18.04 EC2 instance is configured as follows:
 	* `/var/log/auth.log`
 * A `bastion` host record is added to a configurable Route53 DNS zone for the current public IP address of the bastion. This script is also set to run on boot.
 * Automatic updates are configured, using a configurable time to reboot, and the email address to receive errors.
+* By default sudo access is removed from the ubuntu user unless the `remove_root_access` input is set to "false."
 
 ## Using The Bastion
 ### SSH Access to Kubernetes Nodes
@@ -151,6 +152,14 @@ Description: The number of days to retain logs in the CloudWatch Log Group.
 Type: `string`
 
 Default: `"60"`
+
+#### remove\_root\_access
+
+Description: Whether to remove root access from the ubuntu user. Set this to yes|true|1 to remove root access, or anything else to retain it.
+
+Type: `string`
+
+Default: `"true"`
 
 #### ssh\_cidr\_blocks
 

--- a/README.pre_tf_inputs.md
+++ b/README.pre_tf_inputs.md
@@ -11,6 +11,7 @@ The Ubuntu 18.04 EC2 instance is configured as follows:
 	* `/var/log/auth.log`
 * A `bastion` host record is added to a configurable Route53 DNS zone for the current public IP address of the bastion. This script is also set to run on boot.
 * Automatic updates are configured, using a configurable time to reboot, and the email address to receive errors.
+* By default sudo access is removed from the ubuntu user unless the `remove_root_access` input is set to "false."
 
 ## Using The Bastion
 ### SSH Access to Kubernetes Nodes

--- a/bastion-userdata.tmpl
+++ b/bastion-userdata.tmpl
@@ -120,6 +120,17 @@ Unattended-Upgrade::Mail "${unattended_upgrade_email_recipient}";
 ${unattended_upgrade_additional_configs}
 EOF
 
+# Use a temporary variable to more easily compare the lowercase remove_root_access input.
+rra=$(echo ${remove_root_access} |tr '[:upper:]' '[:lower:]')
+if test $rra == "true" -o $rra == "yes" -o $rra == "1" ; then
+  info Removing root access from the ubuntu user as remove_root_access is set to $rra
+  # The ubuntu user has sudo access via both a group and configuration from cloudinit.
+  rm -f /etc/sudoers.d/90-cloud-init-users
+  deluser ubuntu sudo
+else
+  info Retaining root access as remove_root_access is set to \"$rra\"
+fi
+
 info Rebooting, if required by any kernel updates earlier
 test -r /var/run/reboot-required && echo Reboot is required, doing that now... && shutdown -r now
 

--- a/example-usage
+++ b/example-usage
@@ -1,4 +1,4 @@
-fmodule "bastion" {
+module "bastion" {
 
   source = "git@github.com:reactiveops/terraform-bastion.git"
 

--- a/inputs.tf
+++ b/inputs.tf
@@ -28,6 +28,12 @@ variable "unattended_upgrade_additional_configs" {
   default     = ""
 }
 
+variable "remove_root_access" {
+  description = "Whether to remove root access from the ubuntu user. Set this to yes|true|1 to remove root access, or anything else to retain it."
+
+  default = "true"
+}
+
 variable "instance_type" {
   description = "The EC2 instance type of the bastion."
   default     = "t2.micro"

--- a/launchconfig.tf
+++ b/launchconfig.tf
@@ -13,6 +13,8 @@ data "template_file" "bastion_user_data" {
     unattended_upgrade_reboot_time        = "${var.unattended_upgrade_reboot_time}"
     unattended_upgrade_email_recipient    = "${var.unattended_upgrade_email_recipient}"
     unattended_upgrade_additional_configs = "${var.unattended_upgrade_additional_configs}"
+
+    remove_root_access = "${var.remove_root_access}"
   }
 }
 


### PR DESCRIPTION
Users of this module who **do not reference a tag or commit** will recreate their bastion on the next `terraform apply`.

The `remove_root_access` input removes sudo access from the ubuntu user.
This defaults to enabled.
