### PR TITLE
Fix launch config lifecycle, prepare for open sourcing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+## Requirements for Pull Requests
+* Test a `terraform apply` of changes you have introduced, to verify behavior and changes to resources provide the best user experience. If you are unsure, please open an issue or discuss in your pull request.
+* Update the changelog.
+	* Suggest a version bump along with your update, see the changelog  for details.
+* IF you intend to update `README.md`, make changes to one of the `README.*.md` files, then run `make` to generate `README.md`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,23 +2,15 @@
 
 ## Intent
 
-The `bastion` Terraform module is intended to manage a bastion instance per Pentagon inventory, to provide:
+The `bastion` Terraform module is intended to manage a bastion instance to provide:
 
 * SSH access to Kubernetes nodes which do not have a public IP address.
 * API access to a private Kubernetes cluster which uses an internal load balancer.
-* Push-button / easy provisioning as part of provisioning other base resources (VPC, subnets) in an inventory.
+* Push-button / easy provisioning as part of provisioning other base resources (VPC, subnets).
 
 ## Key Design Features
 
-The bastion should be created in any availability zone used by the VPC, and should heal in the event of an availability zone outage. SSH logs should be stored additionally outside the bastion, for good auditing practices and to retain logs if the bastion instance is recreated. The bastion should automatically update operating system packages and reboot as needed when a new kernel is installed.
+The bastion should be created in any availability zone used by the VPC, and should heal in the event of an availability zone outage. SSH logs should additionally be stored outside the bastion, for good auditing practices and to retain logs if the bastion instance is recreated. The bastion should automatically update operating system packages and reboot as needed when a new kernel is installed.
 
 This module should eventually manage a bastion in either Amazon Web Services and Google Compute Cloud.
-
-## Scope
-
-### In Scope:
-
-### Out of Scope:
-
-## Architecture
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017, Reactive Ops Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.post_tf_inputs.md
+++ b/README.post_tf_inputs.md
@@ -1,8 +1,3 @@
-## Future To-do Items
+## Contributing
 
-* Perhaps break this ReadMe out into separate documents to make things more readable.
-* Implement the same thing in Google Cloud.
-* If the preferred usage pattern turns out to be SSH forwarding instead of sshuttle:
-	* Add automation around modifying SSH config and KubeConfig to support using the bastion out of the box.
-	* Explore managing the setup / tear-down of SSH forwarding in Pentagon Workstation (exiting the sub shell tears down the SSH fowrard).
-	
+Thank you for your interest in improving this module. Please see [contributing](./CONTRIBUTING.md) for additional information.

--- a/example-usage
+++ b/example-usage
@@ -1,19 +1,24 @@
+# Example usage for this terraform-bastion module.
 module "bastion" {
+  # Replace v0.2.0 below, with a version number from https://github.com/reactiveops/terraform-bastion/releases
+  source = "git@github.com:reactiveops/terraform-bastion.git?ref=v0.2.0"
 
-  source = "git@github.com:reactiveops/terraform-bastion.git"
-
-  bastion_name = "ro-bastion"
+  bastion_name = "kube-bastion"
 
   # This can also be set in the shell environment, using TF_VAR_infrastructure_bucket
-  infrastructure_bucket = "customername-infrastructure"
+  infrastructure_bucket = "CompanyName-kube-infrastructure"
 
-  # THis allows this module to be used multiple times with different Pentagon inventories.
+  # THis allows this module to use the same S3 bucket for multiple invocations.
   infrastructure_bucket_bastion_key = "default/bastion"
-  route53_zone_id                   = "Z38W0WVE3QXRJ5"
-  vpc_id                            = "${module.vpc.aws_vpc_id}"
-  vpc_subnet_ids                    = ["${module.vpc.aws_subnet_public_ids}"]
+  route53_zone_id                   = "Zxxxxxxxxxxxxx"
 
-  # THis uses the admin-vpn SSH key that Pentagon creates.
-  ssh_public_key_file                = "${file("${path.root}/../config/private/admin-vpn.pub")}"
-  unattended_upgrade_email_recipient = "customername@reactiveops.com"
+  # This gets the VPC and subnet IDs from a separate VPC module,
+  # but you can also specify `vpc-xxx` and `subnet-xxx` IDs directly.
+  vpc_id = "${module.vpc.aws_vpc_id}"
+
+  vpc_subnet_ids = ["${module.vpc.aws_subnet_public_ids}"]
+
+  # This uses an SSH public key from the Terraform root module directory.
+  ssh_public_key_file                = "${file("${path.root}/bastion_ssh.pub")}"
+  unattended_upgrade_email_recipient = "you@example.com"
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -4,11 +4,11 @@ variable "bastion_name" {
 }
 
 variable "infrastructure_bucket" {
-  description = "THe S3 bucket used for infrastructure, the INFRASTRUCTURE_BUCKET Pentagon environment variable. This is intended to be set in the environment via `TF_VAR_infrastructure_bucket`"
+  description = "An S3 bucket to store data that should persist on the bastion when it is recycled by the Auto Scaling Group, such as SSH host keys. This can be set in the environment via `TF_VAR_infrastructure_bucket`"
 }
 
 variable "infrastructure_bucket_bastion_key" {
-  description = "The key; sub-directory in $infrastructure_bucket where the bastion will be allowed to read and write. Do not specify a trailing slash. This location is used to store data that should persist on the bastion when it is recycled by the Auto Scaling Group."
+  description = "The key; sub-directory in $infrastructure_bucket where the bastion will be allowed to read and write. Do not specify a trailing slash. This allows sharing an S3 bucket among multiple invocations of this module."
   default     = "bastion"
 }
 
@@ -42,7 +42,7 @@ variable "instance_type" {
 variable "route53_zone_id" {
   # This zone ID is turned into a zone name by the `register-dns` script,
   # which is created by user-data.
-  description = "ID of the ROute53 zone for the bastion to add its `bastion` record."
+  description = "ID of the ROute53 zone for the bastion to add its host record."
 }
 
 variable "log_retention" {
@@ -51,7 +51,7 @@ variable "log_retention" {
 }
 
 variable "vpc_id" {
-  description = "The VPC ID where the bastion and its security group will be created. This must match subnet IDs specified in the `vpc_subnet_ids` variable"
+  description = "The VPC ID where the bastion and its security group will be created. This must match subnet IDs specified in the `vpc_subnet_ids` input."
 }
 
 variable "vpc_subnet_ids" {

--- a/launchconfig.tf
+++ b/launchconfig.tf
@@ -40,6 +40,6 @@ resource "aws_launch_configuration" "bastion" {
     # DO not recreate the Launch Configuration if a newer AMI becomes available.
     # `terrform taint` the Launch Configuration resource to force it to be recreated.
     # In the future we may want to also include user-data in this list.
-    ignore_changes = ["ami"]
+    ignore_changes = ["image_id"]
   }
 }


### PR DESCRIPTION
The Launch Configuration lifecycle block incorrectly specified ignoring `image_id`  - fixed.

Generalize the example module usage, ReadMe, inputs, and design document before open sourcing
this module.

Add CONTRIBUTING.md and LICENSE.