### PR TITLE
added variables for ami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.2]
+### Added
+
+* Added inputs for the AMI owner and filter, so that a different AMI could be used. Keep in mind that the UserData is strongly biased toward an Ubuntu AMI.
+
 ## [0.3.1]
 ### Changed
 * Ignore tags on the SSH security group.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Default:
 []
 ```
 
+#### ami\_filter\_value
+
+Description: The filter path for the AMI.
+
+Type: `string`
+
+Default: `"ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"`
+
+#### ami\_owner\_id
+
+Description: The ID of the AMI's owner in AWS. The default is Canonical.
+
+Type: `string`
+
+Default: `"099720109477"`
+
 #### bastion\_name
 
 Description: The name of the bastion EC2 instance, DNS hostname, CloudWatch Log Group, and the name prefix for other related resources.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module manages an Amazon Web Services bastion EC2 instance and its Auto Scaling Group, Instance Profile / Role, CloudWatch Log Group, Security Group, and SSH Key Pair. The Auto Scaling Group will recreate the bastion if there is an issue with the EC2 instance or the availability zone where it is running.
 
-The Ubuntu 18.04 EC2 instance is configured as follows:
+The EC2 UserData assumes the Ubuntu operating system, which is configured as follows:
 
 * Packages are updated, and the bastion is rebooted if required.
 * If SSH hostkeys are present in the configurable S3 bucket and path, they are copied to the bastion to retain its previous SSH identity. If there are no host keys in S3, the current keys are copied there.

--- a/README.pre_tf_inputs.md
+++ b/README.pre_tf_inputs.md
@@ -2,7 +2,7 @@
 
 This module manages an Amazon Web Services bastion EC2 instance and its Auto Scaling Group, Instance Profile / Role, CloudWatch Log Group, Security Group, and SSH Key Pair. The Auto Scaling Group will recreate the bastion if there is an issue with the EC2 instance or the availability zone where it is running.
 
-The Ubuntu 18.04 EC2 instance is configured as follows:
+The EC2 UserData assumes the Ubuntu operating system, which is configured as follows:
 
 * Packages are updated, and the bastion is rebooted if required.
 * If SSH hostkeys are present in the configurable S3 bucket and path, they are copied to the bastion to retain its previous SSH identity. If there are no host keys in S3, the current keys are copied there.

--- a/ami.tf
+++ b/ami.tf
@@ -3,10 +3,10 @@ data "aws_ami" "ubuntu" {
   most_recent = true
 
   # THis is Canonical
-  owners = ["099720109477"]
+  owners = ["${var.ami_owner_id}"]
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+    values = ["${var.ami_filter_value}"]
   }
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -79,3 +79,13 @@ variable "ssh_cidr_blocks" {
   description = "A list of CIDRs allowed to SSH to the bastion."
   default     = ["0.0.0.0/0"]
 }
+
+variable "ami_owner_id" {
+  description = "The ID of the AMI's owner in AWS. The default is Canonical."
+  default     = "099720109477" 
+}
+
+variable "ami_filter_value" {
+  description = "The filter path for the AMI."
+  default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
+}


### PR DESCRIPTION
GovCloud had a different owner number for Canonical. Converted the hardcoded values to variables so they could be altered if necessary.