### PR TITLE
make the ARN prefix a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.3]
+### Added
+
+* Added inputs for the ARN prefix to include support for GovCloud.
+
 ## [0.3.2]
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Type: `string`
 
 Default: `"099720109477"`
 
+#### arn\_prefix
+
+Description: The prefix to use for AWS ARNs.
+
+Type: `string`
+
+Default: `"arn:aws"`
+
 #### bastion\_name
 
 Description: The name of the bastion EC2 instance, DNS hostname, CloudWatch Log Group, and the name prefix for other related resources.

--- a/iam.tf
+++ b/iam.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role_policy" "bastion_s3" {
       "s3:ListBucket"
     ],
     "Resource": [
-      "arn:aws:s3:::${var.infrastructure_bucket}"
+      "${var.arn_prefix}:s3:::${var.infrastructure_bucket}"
     ],
     "Effect": "Allow"
   },
@@ -45,7 +45,7 @@ resource "aws_iam_role_policy" "bastion_s3" {
       "s3:GetObject"
     ],
     "Resource": [
-      "arn:aws:s3:::${var.infrastructure_bucket}/${var.infrastructure_bucket_bastion_key}/*"
+      "${var.arn_prefix}:s3:::${var.infrastructure_bucket}/${var.infrastructure_bucket_bastion_key}/*"
     ],
     "Effect": "Allow"
   }
@@ -68,7 +68,7 @@ resource "aws_iam_role_policy" "bastion_logging" {
         "logs:PutLogEvents",
         "logs:DescribeLogStreams"
       ],
-      "Resource": "arn:aws:logs:*:*:log-group:${var.bastion_name}:*",
+      "Resource": "${var.arn_prefix}:logs:*:*:log-group:${var.bastion_name}:*",
       "Effect": "Allow",
       "Sid": "EC2Logging"
     }
@@ -91,7 +91,7 @@ resource "aws_iam_role_policy" "bastion_route53" {
         "route53:ListResourceRecordSets",
         "route53:ChangeResourceRecordSets"
       ],
-      "Resource": "arn:aws:route53:::hostedzone/${var.route53_zone_id}",
+      "Resource": "${var.arn_prefix}:route53:::hostedzone/${var.route53_zone_id}",
       "Effect": "Allow"
     },
     {

--- a/inputs.tf
+++ b/inputs.tf
@@ -89,3 +89,8 @@ variable "ami_filter_value" {
   description = "The filter path for the AMI."
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
 }
+
+variable "arn_prefix" {
+  description = "The prefix to use for AWS ARNs."
+  default = "arn:aws"
+}


### PR DESCRIPTION
GovCloud requires a different ARN prefix. This enables someone to make that change if necessary.