### PR TITLE
Switch to standalone security group rules, make the SSH ingress rule optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.4.2]
 ### Changed
-* The bastion security group now manages its rules as standalone Terraform resources, instead of inline rules, to allow non-Terraform things to manage other rules in the bastion security group. This requires the security group (and bastion) to be recreated, as Terraform does not support a strait forward transition from inline to standalone rules.
+* The bastion security group now manages its rules as standalone Terraform resources, instead of inline rules, to allow non-Terraform things to manage other rules in the bastion security group. This requires the security group (and bastion) to be recreated, as Terraform does not support a straightforward transition from inline to standalone rules.
 
 ### Added
 * The SSH ingress security group rule will not be created if the `ssh_cidr_blocks` module input is an empty list. This allows the module default to be overridden when no SSH rule is desired, if rules will be managed elsewhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.4.2]
+## [0.5.0]
 ### Changed
 * The bastion security group now manages its rules as standalone Terraform resources, instead of inline rules, to allow non-Terraform things to manage other rules in the bastion security group. This requires the security group (and bastion) to be recreated, as Terraform does not support a straightforward transition from inline to standalone rules.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.4.2]
+### Changed
+* The bastion security group now manages its rules as standalone Terraform resources, instead of inline rules, to allow non-Terraform things to manage other rules in the bastion security group. This requires the security group (and bastion) to be recreated, as Terraform does not support a strait forward transition from inline to standalone rules.
+
+### Added
+* The SSH ingress security group rule will not be created if the `ssh_cidr_blocks` module input is an empty list. This allows the module default to be overridden when no SSH rule is desired, if rules will be managed elsewhere.
+
 ## [0.4.1]
 ### Fixed
 * Resolved Terraform 0.12 warnings around quoting.

--- a/inputs.tf
+++ b/inputs.tf
@@ -88,7 +88,7 @@ variable "ssh_public_key_file" {
 
 variable "ssh_cidr_blocks" {
   type        = list(string)
-  description = "A list of CIDRs allowed to SSH to the bastion."
+  description = "A list of CIDRs allowed to SSH to the bastion. Override the module default by specifying an empty list, []"
   default     = ["0.0.0.0/0"]
 }
 

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "bastion_ssh" {
-  name_prefix = "${var.bastion_name}-ssh-egress-"
+  name_prefix = "${var.bastion_name}-"
   description = "Allow inbound Bastion SSH and all outbound traffic"
 
   vpc_id = var.vpc_id

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,25 +1,34 @@
 resource "aws_security_group" "bastion_ssh" {
-  name_prefix = "${var.bastion_name}-ssh-"
+  name_prefix = "${var.bastion_name}-ssh-egress-"
   description = "Allow inbound Bastion SSH and all outbound traffic"
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = var.ssh_cidr_blocks
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   vpc_id = var.vpc_id
+  # Destroy other non-Terraform-managed rules, if the security group needs to be destroyed.
+  revoke_rules_on_delete = true
 
   lifecycle {
     ignore_changes = [tags]
   }
 }
 
+resource "aws_security_group_rule" "bastion_ssh" {
+  # Only add this rule if the list of ssh_cidr_blocks is set.
+  count             = length(var.ssh_cidr_blocks) > 0 ? 1 : 0
+  type              = "ingress"
+  description       = "Terraform-managed SSH access"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = var.ssh_cidr_blocks
+  security_group_id = aws_security_group.bastion_ssh.id
+}
+
+resource "aws_security_group_rule" "bastion_egress" {
+  type              = "egress"
+  description       = "Terraform-managed bastion egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.bastion_ssh.id
+}


### PR DESCRIPTION
Switching to standalone security group rules allows non-Terraform things
to manage rules in the bastion security group. This transition requires recreating
the security group.

The SSH ingress security group rule will not be created, if the `ssh_cidr_blocks` input is an empty list. This allows overriding the module default, if SSH ingress rules will be managed elsewhere.