### PR TITLE
Conditionally set AMI data source to search in GovCloud.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Bastion Modules
 
-These Terraform modules manage an Amazon Web Services (AWS) or Google Cloud (GCP) bastion and its Auto Scaling Group, Identity and Access Management (IAM) resources, remote logging, SSH users and firewall access. The Auto Scaling Group will recreate the bastion if there is an issue with the compute instance or the availability zone where it is running.
+These Terraform modules manage an Amazon Web Services (AWS) or Google Cloud Platform (GCP) bastion and its Auto Scaling Group, Identity and Access Management (IAM) resources, remote logging, SSH users and firewall access. The Auto Scaling Group will recreate the bastion if there is an issue with the compute instance or the AWS availability zone where it is running.
 
 The configuration scripts assume the Ubuntu operating system, which is configured as follows:
 

--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [aws-v0.6.2]
+
+* Add input variable for retrieving AMIs within an AWS GovCloud account. Use this value automatically when `arn_prefix` is set to an AWS partition other than `aws`, i.e., when the `arn_prefix` has a value other than `arn:aws`.
+
 ## [aws-v0.6.1]
 
 * Update user-data to not include a `dist-upgrade`

--- a/aws/README.md
+++ b/aws/README.md
@@ -176,6 +176,14 @@ Type: `string`
 
 Default: `"099720109477"`
 
+#### ami\_owner\_id\_govcloud
+
+Description: The ID of the AMI's owner in AWS GovCloud. This value is used automatically if the module's `arn_prefix` input variable is anything other than `arn:aws`. The default is Canonical.
+
+Type: `string`
+
+Default: `"513442679011"`
+
 #### arn\_prefix
 
 Description: The prefix to use for AWS ARNs.

--- a/aws/ami.tf
+++ b/aws/ami.tf
@@ -2,8 +2,8 @@
 data "aws_ami" "ubuntu" {
   most_recent = true
 
-  # THis is Canonical
-  owners = [var.ami_owner_id]
+  # This is Canonical
+  owners = [var.arn_prefix == "arn:aws" ? var.ami_owner_id : var.ami_owner_id_govcloud]
 
   filter {
     name   = "name"

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -91,6 +91,11 @@ variable "ami_owner_id" {
   default     = "099720109477"
 }
 
+variable "ami_owner_id_govcloud" {
+  description = "The ID of the AMI's owner in AWS GovCloud. The default is Canonical."
+  default     = "513442679011"
+}
+
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
   default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -92,7 +92,7 @@ variable "ami_owner_id" {
 }
 
 variable "ami_owner_id_govcloud" {
-  description = "The ID of the AMI's owner in AWS GovCloud. The default is Canonical."
+  description = "The ID of the AMI's owner in AWS GovCloud. This value is used automatically if the module's `arn_prefix` input variable is anything other than `arn:aws`. The default is Canonical."
   default     = "513442679011"
 }
 


### PR DESCRIPTION
This pull request adds support for AWS GovCloud by ensuring that a sensible default (Canonical, Inc's AMI owner ID in GovCloud) is used for searching for Canonical AMIs when the `arn_prefix` variable indicates that the bastion should be deployed into an AWS partition other than the regular AWS commercial one.