### PR TITLE
Bastions are always launched in public subnets, so this is not needed.

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [aws-v1.0.0]
+
+* Remove `associate_public_ip_address` argument; this is a potentially backwards-incompatible change that will cause public IP address allocation for the host to be determined based on the subnet in which the bastion host is launched. To ensure bastion hosts still receive public IP addresses, make sure they are launched within a public subnet.
+
 ## [aws-v0.6.2]
 
 * Add input variable for retrieving AMIs within an AWS GovCloud account. Use this value automatically when `arn_prefix` is set to an AWS partition other than `aws`, i.e., when the `arn_prefix` has a value other than `arn:aws`.

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -32,7 +32,6 @@ resource "aws_launch_configuration" "bastion" {
 
   iam_instance_profile        = aws_iam_instance_profile.bastion.name
   security_groups             = [aws_security_group.bastion_ssh.id]
-  associate_public_ip_address = "true"
 
   user_data_base64 = base64gzip(data.template_file.bastion_user_data.rendered)
   key_name         = aws_key_pair.bastion.id


### PR DESCRIPTION
I ran into another problem with bastions in GovCloud: the `aws_launch_configuration` resource for the bastion is unconditionally setting its `associate_public_ip_address` argument to `true` in the HCL source. While this works for the AWS commercial partition, the GovCloud partition refuses to launch instances from launch configurations configured in this way with the error:

```
The requested configuration is currently not supported.
```

There are actually three possible values for this argument in the AWS Management Console:

1. the default, which leaves the decision of whether or not to associate a public IP address to the subnet in which the instance was launched (yes for a public subnet, no for a private subnet),
2. a value called "every" (which maps to `true` in HCL), which is what the code is currently doing,
3. a value called "none" (which maps to `false` in HCL), which would prevent public IP address allocation for the launched instance.

I believe what we actually want is the default setting, not the `true` value, because as far as I can tell, bastion hosts are by definition *always* launched inside of public subnets. By removing this precision from the HCL source code, I think we can accommodate both AWS commercial partitions and GovCloud partitions.