### PR TITLE
Userdata script updates for both AWS and GCP

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [aws-v2.0.1]
+* Update startup-script so that the upgrade command runs as an `at`. This is a bugfix in the situation that it upgrades a package that could restart the startup-script and DNS Update + user creation will never happen.
 ## [aws-v2.0.0]
 
 * Revert the previous change to `associate_public_ip_address` as there were [unintended consequences](https://github.com/FairwindsOps/terraform-bastion/pull/44) with the default value.

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -23,7 +23,9 @@ ucf --purge /boot/grub/menu.lst
 export DEBIAN_FRONTEND=noninteractive
 info Updating packages. . .
 apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" update
-apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+
+info Triggering a job using at, to sleep then run apt-get upgrade...
+echo "sleep 120 ; apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade" |at now
 
 info Installing packages needed on the bastion...
 apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install awscli python unattended-upgrades

--- a/gcp/CHANGELOG.md
+++ b/gcp/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [gcp-v0.1.3]
+* Update startup-script so that the upgrade command runs as an `at`. This is a bugfix in the situation that it upgrade `google-guest-agent` which would restart the startup-script and DNS Update + user creation will never happen.
 ## [gcp-v0.1.2]
 
 * Update startup-script to not include a `dist-upgrade`

--- a/gcp/bastion-startup-script.tmpl
+++ b/gcp/bastion-startup-script.tmpl
@@ -36,7 +36,9 @@ ucf --purge /boot/grub/menu.lst
 export DEBIAN_FRONTEND=noninteractive
 info Updating packages. . .
 apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" update
-apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+
+info Triggering a job using at, to sleep then run apt-get upgrade...
+echo "sleep 120 ; apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade" |at now
 
 info Installing packages needed on the bastion...
 apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install python unattended-upgrades


### PR DESCRIPTION
Move the apt-get upgrade portion of the userdata script to run as an `at` job so as not to risk having one of the upgrades restart the startup script.