### PR TITLE
Add ALB support and make Route53 zone optional

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -148,6 +148,14 @@ Type: `list`
 
 Default: `[]`
 
+#### alb\_name
+
+Description: Name of Load Balancer to create for the bastion. To attach an existing Load Balancer, let this parameter empty and add `aws_autoscaling_attachment` resource with `autoscaling_group_id` output and your load balancer id.
+
+Type: `string`
+
+Default: `""`
+
 #### ami\_filter\_value
 
 Description: The filter path for the AMI.
@@ -277,6 +285,18 @@ Default: `"21:30"`
 ### Outputs
 
 The following outputs are exported:
+
+#### alb\_arn
+
+Description: The ARN of the bastion load balancer
+
+#### alb\_dns\_name
+
+Description: The DNS name of the bastion load balancer
+
+#### alb\_id
+
+Description: The ID of the bastion load balancer
 
 #### security\_group\_id
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -102,12 +102,6 @@ Description: An S3 bucket to store data that should persist on the bastion when 
 
 Type: `any`
 
-#### route53\_zone\_id
-
-Description: ID of the ROute53 zone for the bastion to add its host record.
-
-Type: `any`
-
 #### unattended\_upgrade\_email\_recipient
 
 Description: An email address where unattended upgrade errors should be emailed. THis sets the option in /etc/apt/apt.conf.d/50unattended-upgrades
@@ -233,6 +227,14 @@ Description: Whether to remove root access from the ubuntu user. Set this to yes
 Type: `string`
 
 Default: `"true"`
+
+#### route53\_zone\_id
+
+Description: ID of the ROute53 zone for the bastion to add its host record.
+
+Type: `string`
+
+Default: `""`
 
 #### ssh\_cidr\_blocks
 

--- a/aws/alb.tf
+++ b/aws/alb.tf
@@ -1,0 +1,49 @@
+resource "aws_alb" "bastion_alb" {
+  count = var.alb_name == "" ? 0 : 1
+
+  name                             = var.alb_name
+  internal                         = false
+  load_balancer_type               = "network"
+  subnets                          = flatten(var.vpc_subnet_ids)
+  enable_cross_zone_load_balancing = true
+}
+
+resource "aws_alb_listener" "bastion_alb" {
+  count = var.alb_name == "" ? 0 : 1
+
+  load_balancer_arn = aws_alb.bastion_alb[0].arn
+  port              = 22
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.bastion_alb[0].arn
+    type             = "forward"
+  }
+
+  depends_on = [aws_alb_target_group.bastion_alb[0]]
+}
+
+resource "aws_alb_target_group" "bastion_alb" {
+  count = var.alb_name == "" ? 0 : 1
+
+  name     = var.alb_name
+  port     = 22
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    enabled             = true
+    port                = 22
+    protocol            = "TCP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    interval            = 30
+  }
+}
+
+resource "aws_autoscaling_attachment" "bastion" {
+  count = var.alb_name == "" ? 0 : 1
+
+  autoscaling_group_name = aws_autoscaling_group.bastion.id
+  elb                    = aws_alb.bastion_alb.id
+}

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -22,6 +22,9 @@ resource "aws_autoscaling_group" "bastion" {
   # THis needs to match the Launch Configuration.
   lifecycle {
     create_before_destroy = true
+
+    # Allow end user to attach a load balancer with `aws_autoscaling_attachment`.
+    ignore_changes = [load_balancers, target_group_arns]
   }
 }
 

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -82,44 +82,51 @@ info "Configuring CloudWatch Agent. . ." && \
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:cloudwatch-agent.conf -s && \
 rm -f cloudwatch-agent.conf cloudwatch-agent.deb
 
-info Setting up DNS registration on boot
-info Downloading the cli53 tool
-curl -Lo /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.13/cli53-linux-amd64
-chmod +x /usr/local/bin/cli53
-info Creating the /usr/local/bin/register-dns script using route53 zone ID ${zone_id}. . .
-cat <<'EOF' >/usr/local/bin/register-dns
-#!/bin/bash
-
 zone_id="${zone_id}"
-bastion_name="${bastion_name}"
-public_ip=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-zone_name=$(cli53 list -f csv |grep ${zone_id}|cut -d, -f2)
 
-echo $0 - registering $${bastion_name}.$${zone_name} to IP $${public_ip} using zone ID $${zone_id}...
+if [ ! -z "$zone_id" ]
+then
+  info Setting up DNS registration on boot
+  info Downloading the cli53 tool
+  curl -Lo /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.13/cli53-linux-amd64
+  chmod +x /usr/local/bin/cli53
+  info Creating the /usr/local/bin/register-dns script using route53 zone ID ${zone_id}. . .
+  cat <<'EOF' >/usr/local/bin/register-dns
+  #!/bin/bash
 
-cli53 rrcreate --replace \
-$${zone_id} "$${bastion_name} 60 A $${public_ip}"
+  zone_id="${zone_id}"
+  bastion_name="${bastion_name}"
+  public_ip=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+  zone_name=$(cli53 list -f csv |grep ${zone_id}|cut -d, -f2)
 
-EOF
-chmod +x /usr/local/bin/register-dns
+  echo $0 - registering $${bastion_name}.$${zone_name} to IP $${public_ip} using zone ID $${zone_id}...
 
-info Installing the register-dns systemd service
-cat <<EOF >/etc/systemd/system/register-dns.service
-[Unit]
-Description=Register the public IP address in DNS
-
-[Service]
-ExecStart=/usr/local/bin/register-dns
-Type=oneshot
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
+  cli53 rrcreate --replace \
+  $${zone_id} "$${bastion_name} 60 A $${public_ip}"
 
 EOF
-systemctl daemon-reload
-systemctl enable register-dns
-systemctl start register-dns
+  chmod +x /usr/local/bin/register-dns
+
+  info Installing the register-dns systemd service
+  cat <<EOF >/etc/systemd/system/register-dns.service
+  [Unit]
+  Description=Register the public IP address in DNS
+
+  [Service]
+  ExecStart=/usr/local/bin/register-dns
+  Type=oneshot
+  RemainAfterExit=yes
+
+  [Install]
+  WantedBy=multi-user.target
+
+EOF
+  systemctl daemon-reload
+  systemctl enable register-dns
+  systemctl start register-dns
+else
+  info Skip DNS registration on boot
+fi
 
 info Configuring unattended upgrades in /etc/apt/apt.conf.d/50unattended-upgrades
 cat <<EOF >>/etc/apt/apt.conf.d/50unattended-upgrades

--- a/aws/example-usage
+++ b/aws/example-usage
@@ -13,7 +13,10 @@ module "bastion" {
 
   # This allows this module to use the same S3 bucket for multiple invocations.
   infrastructure_bucket_bastion_key = "default/bastion"
+
+  # Either a Route53 zone id or ALB name should be defined.
   route53_zone_id                   = "Zxxxxxxxxxxxxx"
+  # alb_name                        = "kube-bastion"
 
   # This gets the VPC and subnet IDs from a separate VPC module,
   # but you can also specify `vpc-xxx` and `subnet-xxx` IDs directly.

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -81,6 +81,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "bastion_route53" {
+  count = var.route53_zone_id == "" ? 0 : 1
+
   name = "bastion-route53"
   role = aws_iam_role.bastion_role.id
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -60,6 +60,7 @@ variable "route53_zone_id" {
   # This zone ID is turned into a zone name by the `register-dns` script,
   # which is created by user-data.
   description = "ID of the ROute53 zone for the bastion to add its host record."
+  default = ""
 }
 
 variable "log_retention" {

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -63,6 +63,11 @@ variable "route53_zone_id" {
   default = ""
 }
 
+variable "alb_name" {
+  description = "Name of Load Balancer to create for the bastion. To attach an existing Load Balancer, let this parameter empty and add `aws_autoscaling_attachment` resource with `autoscaling_group_id` output and your load balancer id."
+  default = ""
+}
+
 variable "log_retention" {
   description = "The number of days to retain logs in the CloudWatch Log Group."
   default     = "60"

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -2,3 +2,18 @@ output "security_group_id" {
   value       = aws_security_group.bastion_ssh.id
   description = "The ID of the bastion security group"
 }
+
+output "alb_dns_name" {
+  value       = aws_alb.bastion_alb[0].dns_name
+  description = "The DNS name of the bastion load balancer"
+}
+
+output "alb_arn" {
+  value       = aws_alb.bastion_alb[0].arn
+  description = "The ARN of the bastion load balancer"
+}
+
+output "alb_id" {
+  value       = aws_alb.bastion_alb[0].id
+  description = "The ID of the bastion load balancer"
+}


### PR DESCRIPTION
This bring optional support for an ALB to make the bastion instance available with no requirements to Route53.

In my use case, domain is hosted at cloudflare, so I can configure it with a CNAME pointing to ALB dns name. Other users could also access the bastion using ALB dns name if they don't want to setup the bastion in their own domain.

```terraform
provider "cloudflare" {
}

resource "cloudflare_record" "bastion" {
  zone_id = var.cloudflare_zone_id
  name    = "bastion"
  value   = module.bastion.alb_dns_name
  type    = "CNAME"
  proxied = false
}
```