### PR TITLE
Make ssh_public_key_file optional

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -41,7 +41,7 @@ host 172.20.*.*
 You can now SSH directly to IP addresses within `172.20.0.0/16`, and your connection will be proxied through the bastion.
 
 
-### Accessing a Private Kubernetes API
+### Accessing a Private Kubernetes API 
 
 You can proxy access to a private Kubernetes API through the bastion, instead of using a VPN.
 
@@ -105,12 +105,6 @@ Type: `any`
 #### route53\_zone\_id
 
 Description: ID of the ROute53 zone for the bastion to add its host record.
-
-Type: `any`
-
-#### ssh\_public\_key\_file
-
-Description: The content of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. Yes, this input has an unfortunate name.
 
 Type: `any`
 
@@ -254,6 +248,14 @@ Default:
 ]
 ```
 
+#### ssh\_public\_key\_file
+
+Description: The content of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. Yes, this input has an unfortunate name.
+
+Type: `string`
+
+Default: `""`
+
 #### unattended\_upgrade\_additional\_configs
 
 Description: Additional configuration lines to add to /etc/apt/apt.conf.d/50unattended-upgrades
@@ -272,11 +274,16 @@ Default: `"21:30"`
 
 ### Outputs
 
-`security_group_id`: The ID of the bastion security group
+The following outputs are exported:
+
+#### security\_group\_id
+
+Description: The ID of the bastion security group
+
 
 ## Additional Design Considerations
 
-The [design document](./DESIGN.md) describes the goals and vision for this project.
+The [design document](./DESIGN.md) describes the goals and vision for this project. 
 
 ## Contributing
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -78,6 +78,7 @@ variable "vpc_subnet_ids" {
 
 variable "ssh_public_key_file" {
   description = "The content of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. Yes, this input has an unfortunate name."
+  default     = ""
 }
 
 variable "ssh_cidr_blocks" {

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -35,7 +35,7 @@ resource "aws_launch_configuration" "bastion" {
   associate_public_ip_address = "true"
 
   user_data_base64 = base64gzip(data.template_file.bastion_user_data.rendered)
-  key_name         = aws_key_pair.bastion.id
+  key_name         = length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null
 
   root_block_device {
     encrypted = var.encrypt_root_volume

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,3 +1,4 @@
 output "security_group_id" {
-  value = aws_security_group.bastion_ssh.id
+  value       = aws_security_group.bastion_ssh.id
+  description = "The ID of the bastion security group"
 }

--- a/aws/ssh-keypair.tf
+++ b/aws/ssh-keypair.tf
@@ -1,4 +1,6 @@
 resource "aws_key_pair" "bastion" {
+  count = var.ssh_public_key_file == "" ? 0 : 1
+
   key_name_prefix = "${var.bastion_name}-"
   public_key      = var.ssh_public_key_file
 }


### PR DESCRIPTION
This field doesn't seems to be mandatory for those using additional_users features