### PR TITLE
add additional_script_files to be loaded on EC2 instance creation

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [aws-unreleased]
+* Add `additional_script_files` to support local script files integration.
+
 ## [aws-v3.0.0]
 * Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -90,6 +90,8 @@ The following providers are used by this module:
 
 - aws (>=2.30.0)
 
+- local
+
 - template
 
 ### Required Inputs
@@ -135,6 +137,14 @@ The following input variables are optional (have default values):
 Description: Additional users to be created on the bastion. Works the same as additional\_users, but adds users via a separate systemd unit file. Specify users as a list of maps. See an example in the `example-usage` file. Required map keys are `login` (user name) and `authorized_keys`. Optional map keys are `gecos` (full name), `supplemental_groups` (comma-separated), and `shell`. The authorized\_keys will be output to ~/.ssh/authorized\_keys using printf - multiple keys can be specified by including \n in the string.
 
 Type: `list`
+
+Default: `[]`
+
+#### additional\_script\_files
+
+Description: Additional script files, which are run the first time the bastion EC2 boots.
+
+Type: `list(string)`
 
 Default: `[]`
 

--- a/aws/additional_script.tf
+++ b/aws/additional_script.tf
@@ -1,0 +1,4 @@
+data "local_file" "additional_scripts" {
+  count    = length(var.additional_script_files)
+  filename = var.additional_script_files[count.index]
+}

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -180,6 +180,9 @@ else
   info Retaining root access as remove_root_access is set to \"$rra\"
 fi
 
+# Additional scripts loaded from files declared in additional_script_files module input.
+${additional_scripts}
+
 info Rebooting, if required by any kernel updates earlier
 test -r /var/run/reboot-required && echo Reboot is required, doing that now... && shutdown -r now
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -51,6 +51,12 @@ variable "additional_user_data" {
   default     = ""
 }
 
+variable "additional_script_files" {
+  type = list(string)
+  description = "Additional script files, which are run the first time the bastion EC2 boots."
+  default     = []
+}
+
 variable "instance_type" {
   description = "The EC2 instance type of the bastion."
   default     = "t2.micro"

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -18,6 +18,7 @@ data "template_file" "bastion_user_data" {
     additional_user_templates                                   = join("\n", data.template_file.additional_user.*.rendered)
     infrastructure_bucket_additional_external_users_script_etag = aws_s3_bucket_object.additional-external-users-script.etag
     additional-external-users-script-md5                        = local.additional-external-users-script-md5
+    additional_scripts                                          = join("\n", data.local_file.additional_scripts.*.content)
   }
 }
 


### PR DESCRIPTION
This can be used to execute additional commands from files available in terraform module directory.