### PR TITLE
Update required providers to format for v0.13+

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [aws-v3.0.0]
+* Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13
+
 ## [aws-v2.1.0]
 * Add input to encrypt the root volume (true by default).
 
 ## [aws-v2.0.1]
 * Update startup-script so that the upgrade command runs as an `at`. This is a bugfix in the situation that it upgrades a package that could restart the startup-script and DNS Update + user creation will never happen.
+
 ## [aws-v2.0.0]
 
 * Revert the previous change to `associate_public_ip_address` as there were [unintended consequences](https://github.com/FairwindsOps/terraform-bastion/pull/44) with the default value.

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,7 +1,17 @@
 
+# terraform {
+#   required_version = ">= 0.12"
+#   required_providers {
+#     aws = ">=2.30.0"
+#   }
+# }
+
 terraform {
-  required_version = ">= 0.12"
+  version = ">= 0.13"
   required_providers {
-    aws = ">=2.30.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=2.30.0"
+    }
   }
 }

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -7,7 +7,7 @@
 # }
 
 terraform {
-  version = ">= 0.13"
+  required_version = ">= 0.13"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/aws/versions.tf
+++ b/aws/versions.tf
@@ -1,11 +1,4 @@
 
-# terraform {
-#   required_version = ">= 0.12"
-#   required_providers {
-#     aws = ">=2.30.0"
-#   }
-# }
-
 terraform {
   required_version = ">= 0.13"
   required_providers {

--- a/gcp/CHANGELOG.md
+++ b/gcp/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [gcp-v1.0.0]
+* Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13
+
 ## [gcp-v0.1.3]
 * Update startup-script so that the upgrade command runs as an `at`. This is a bugfix in the situation that it upgrade `google-guest-agent` which would restart the startup-script and DNS Update + user creation will never happen.
+
 ## [gcp-v0.1.2]
 
 * Update startup-script to not include a `dist-upgrade`

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -1,8 +1,18 @@
 
+# terraform {
+#   required_version = ">= 0.12"
+#   required_providers {
+#     google   = ">=2.0.0"
+#     template = ">=2.1.2"
+#   }
+# }
+
 terraform {
-  required_version = ">= 0.12"
+  version = ">= 0.13"
   required_providers {
-    google   = ">=2.0.0"
-    template = ">=2.1.2"
+    google = {
+      source  = "hashicorp/google"
+      version = ">=2.0.0"
+    }
   }
 }

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -1,12 +1,4 @@
 
-# terraform {
-#   required_version = ">= 0.12"
-#   required_providers {
-#     google   = ">=2.0.0"
-#     template = ">=2.1.2"
-#   }
-# }
-
 terraform {
   required_version = ">= 0.13"
   required_providers {

--- a/gcp/versions.tf
+++ b/gcp/versions.tf
@@ -8,7 +8,7 @@
 # }
 
 terraform {
-  version = ">= 0.13"
+  required_version = ">= 0.13"
   required_providers {
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
- introduces breaking change between 0.12 to 0.13+
- terraform version must be >=0.13