### PR TITLE
add `ssh_key_name` input to use a `aws_key_pair` resource provided by user

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [aws-unreleased]
 * Add input variable `additional_user_data_end` to execute commands after users creation.
+* Add `ssh_key_name` to support external `aws_key_pair` resource.
 
 ## [aws-v3.0.0]
 * Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13

--- a/aws/README.md
+++ b/aws/README.md
@@ -256,9 +256,17 @@ Default:
 ]
 ```
 
+#### ssh\_key\_name
+
+Description: Key name of a pre-existing AWS SSH Key Pair to use. This input is mutually exclusive with the `ssh_public_key_file` input, which can be used instead to create a new Key Pair.
+
+Type: `string`
+
+Default: `""`
+
 #### ssh\_public\_key\_file
 
-Description: The content of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. Yes, this input has an unfortunate name.
+Description: The *content* of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. This input is mutually exclusive with the `ssh_key_name` input, which can be used instead to reference a pre-existing Key Pair.
 
 Type: `string`
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -81,8 +81,13 @@ variable "vpc_subnet_ids" {
   description = "A list of subnet IDs where the Auto Scaling Group can place the bastion."
 }
 
+variable "ssh_key_name" {
+  description = "Key name of a pre-existing AWS SSH Key Pair to use. This input is mutually exclusive with the `ssh_public_key_file` input, which can be used instead to create a new Key Pair."
+  default     = ""
+}
+
 variable "ssh_public_key_file" {
-  description = "The content of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. Yes, this input has an unfortunate name."
+  description = "The *content* of an existing SSH public key file, that will be used to create an AWS SSH Key Pair. This input is mutually exclusive with the `ssh_key_name` input, which can be used instead to reference a pre-existing Key Pair."
   default     = ""
 }
 

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -36,7 +36,7 @@ resource "aws_launch_configuration" "bastion" {
   associate_public_ip_address = "true"
 
   user_data_base64 = base64gzip(data.template_file.bastion_user_data.rendered)
-  key_name         = length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null
+  key_name         = var.ssh_key_name != "" ? var.ssh_key_name : (length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null)
 
   root_block_device {
     encrypted = var.encrypt_root_volume


### PR DESCRIPTION
This PR fixes issue #59

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?

