### PR TITLE
add autoscaling_group_id and autoscaling_group_arn outputs

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Add `ssh_key_name` to support external `aws_key_pair` resource.
 * Make userdata exit with code 0 when no reboot is required. This avoid cloud-init status to report an error.
 * `route53_zone_id` is now optional.
+* Add `autoscaling_group_id` and `autoscaling_group_arn` outputs. Those new outputs can be used to attached a Load Balancer with [autoscaling_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment#with-an-autoscaling-group-resource).
 
 ## [aws-v3.0.0]
 * Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13

--- a/aws/README.md
+++ b/aws/README.md
@@ -294,6 +294,14 @@ Default: `"21:30"`
 
 The following outputs are exported:
 
+#### autoscaling\_group\_arn
+
+Description: The ARN of the autoscaling group
+
+#### autoscaling\_group\_id
+
+Description: The ID of the autoscaling group
+
 #### security\_group\_id
 
 Description: The ID of the bastion security group

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -22,6 +22,9 @@ resource "aws_autoscaling_group" "bastion" {
   # THis needs to match the Launch Configuration.
   lifecycle {
     create_before_destroy = true
+
+    # Allow end user to attach a load balancer with `aws_autoscaling_attachment`.
+    ignore_changes = [load_balancers, target_group_arns]
   }
 }
 

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -2,3 +2,13 @@ output "security_group_id" {
   value       = aws_security_group.bastion_ssh.id
   description = "The ID of the bastion security group"
 }
+
+output "autoscaling_group_id" {
+  value       = aws_autoscaling_group.bastion.id
+  description = "The ID of the autoscaling group"
+}
+
+output "autoscaling_group_arn" {
+  value       = aws_autoscaling_group.bastion.arn
+  description = "The ARN of the autoscaling group"
+}


### PR DESCRIPTION
This PR fixes issue https://github.com/FairwindsOps/terraform-bastion/pull/51#issuecomment-1015478107

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Output autoscaling group information for end user to attach a custom or existing load balancer.

### What changes did you make?

### What alternative solution should we consider, if any?

