### PR TITLE
make route53_zone_id optional

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [aws-unreleased]
 * Add input variable `additional_user_data_end` to execute commands after users creation.
+* `route53_zone_id` is now optional.
 
 ## [aws-v3.0.0]
 * Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13

--- a/aws/README.md
+++ b/aws/README.md
@@ -102,12 +102,6 @@ Description: An S3 bucket to store data that should persist on the bastion when 
 
 Type: `any`
 
-#### route53\_zone\_id
-
-Description: ID of the ROute53 zone for the bastion to add its host record.
-
-Type: `any`
-
 #### unattended\_upgrade\_email\_recipient
 
 Description: An email address where unattended upgrade errors should be emailed. THis sets the option in /etc/apt/apt.conf.d/50unattended-upgrades
@@ -241,6 +235,14 @@ Description: Whether to remove root access from the ubuntu user. Set this to yes
 Type: `string`
 
 Default: `"true"`
+
+#### route53\_zone\_id
+
+Description: ID of the ROute53 zone for the bastion to add its host record.
+
+Type: `string`
+
+Default: `""`
 
 #### ssh\_cidr\_blocks
 

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -82,44 +82,51 @@ info "Configuring CloudWatch Agent. . ." && \
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:cloudwatch-agent.conf -s && \
 rm -f cloudwatch-agent.conf cloudwatch-agent.deb
 
-info Setting up DNS registration on boot
-info Downloading the cli53 tool
-curl -Lo /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.13/cli53-linux-amd64
-chmod +x /usr/local/bin/cli53
-info Creating the /usr/local/bin/register-dns script using route53 zone ID ${zone_id}. . .
-cat <<'EOF' >/usr/local/bin/register-dns
-#!/bin/bash
-
 zone_id="${zone_id}"
-bastion_name="${bastion_name}"
-public_ip=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-zone_name=$(cli53 list -f csv |grep ${zone_id}|cut -d, -f2)
 
-echo $0 - registering $${bastion_name}.$${zone_name} to IP $${public_ip} using zone ID $${zone_id}...
+if [ ! -z "$zone_id" ]
+then
+  info Setting up DNS registration on boot
+  info Downloading the cli53 tool
+  curl -Lo /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.13/cli53-linux-amd64
+  chmod +x /usr/local/bin/cli53
+  info Creating the /usr/local/bin/register-dns script using route53 zone ID ${zone_id}. . .
+  cat <<'EOF' >/usr/local/bin/register-dns
+  #!/bin/bash
 
-cli53 rrcreate --replace \
-$${zone_id} "$${bastion_name} 60 A $${public_ip}"
+  zone_id="${zone_id}"
+  bastion_name="${bastion_name}"
+  public_ip=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+  zone_name=$(cli53 list -f csv |grep ${zone_id}|cut -d, -f2)
 
-EOF
-chmod +x /usr/local/bin/register-dns
+  echo $0 - registering $${bastion_name}.$${zone_name} to IP $${public_ip} using zone ID $${zone_id}...
 
-info Installing the register-dns systemd service
-cat <<EOF >/etc/systemd/system/register-dns.service
-[Unit]
-Description=Register the public IP address in DNS
-
-[Service]
-ExecStart=/usr/local/bin/register-dns
-Type=oneshot
-RemainAfterExit=yes
-
-[Install]
-WantedBy=multi-user.target
+  cli53 rrcreate --replace \
+  $${zone_id} "$${bastion_name} 60 A $${public_ip}"
 
 EOF
-systemctl daemon-reload
-systemctl enable register-dns
-systemctl start register-dns
+  chmod +x /usr/local/bin/register-dns
+
+  info Installing the register-dns systemd service
+  cat <<EOF >/etc/systemd/system/register-dns.service
+  [Unit]
+  Description=Register the public IP address in DNS
+
+  [Service]
+  ExecStart=/usr/local/bin/register-dns
+  Type=oneshot
+  RemainAfterExit=yes
+
+  [Install]
+  WantedBy=multi-user.target
+
+EOF
+  systemctl daemon-reload
+  systemctl enable register-dns
+  systemctl start register-dns
+else
+  info Skip DNS registration on boot
+fi
 
 info Configuring unattended upgrades in /etc/apt/apt.conf.d/50unattended-upgrades
 cat <<EOF >>/etc/apt/apt.conf.d/50unattended-upgrades

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -81,6 +81,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "bastion_route53" {
+  count = var.route53_zone_id == "" ? 0 : 1
+
   name = "bastion-route53"
   role = aws_iam_role.bastion_role.id
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -65,6 +65,7 @@ variable "route53_zone_id" {
   # This zone ID is turned into a zone name by the `register-dns` script,
   # which is created by user-data.
   description = "ID of the ROute53 zone for the bastion to add its host record."
+  default = ""
 }
 
 variable "log_retention" {


### PR DESCRIPTION
This PR fixes issue https://github.com/FairwindsOps/terraform-bastion/pull/51

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

This is same as https://github.com/FairwindsOps/terraform-bastion/pull/51, but doesn't contains the Load Balancer part. Along with #61, end user could bring it's own load balancer to publish the bastion.

### What changes did you make?

### What alternative solution should we consider, if any?

