### PR TITLE
add additional_user_data_end input

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [aws-unreleased]
+* Add input variable `additional_user_data_end` to execute commands after users creation.
+
 ## [aws-v3.0.0]
 * Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -140,7 +140,15 @@ Default: `[]`
 
 #### additional\_user\_data
 
-Description: Content to be appended to UserData, which is run the first time the bastion EC2 boots.
+Description: Content to be appended to UserData, which is run the first time the bastion EC2 boots, before additional users are created.
+
+Type: `string`
+
+Default: `""`
+
+#### additional\_user\_data\_end
+
+Description: Content to be appended to UserData, which is run the first time the bastion EC2 boots, after additional users are created.
 
 Type: `string`
 

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -131,7 +131,7 @@ Unattended-Upgrade::Mail "${unattended_upgrade_email_recipient}";
 ${unattended_upgrade_additional_configs}
 EOF
 
-# Execute optional additional user data.
+# Execute optional additional user data (before additional users are created).
 if [ "$${additional_user_data}x" == "x" ] ; then
   info "Executing additional_user_data. . ."
   ${additional_user_data}
@@ -168,6 +168,13 @@ EOF
 systemctl daemon-reload
 systemctl enable additional-external-users
 systemctl start additional-external-users
+
+# Execute optional additional user data (after additional users are created).
+if [ "$${additional_user_data_end}x" == "x" ] ; then
+  info "Executing additional_user_data_end. . ."
+  ${additional_user_data_end}
+  info "Finished executing additional_user_data_end. . ."
+fi
 
 # Use a temporary variable to more easily compare the lowercase remove_root_access input.
 rra=$(echo ${remove_root_access} |tr '[:upper:]' '[:lower:]')

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -47,7 +47,12 @@ variable "additional_external_users" {
 }
 
 variable "additional_user_data" {
-  description = "Content to be appended to UserData, which is run the first time the bastion EC2 boots."
+  description = "Content to be appended to UserData, which is run the first time the bastion EC2 boots, before additional users are created."
+  default     = ""
+}
+
+variable "additional_user_data_end" {
+  description = "Content to be appended to UserData, which is run the first time the bastion EC2 boots, after additional users are created."
   default     = ""
 }
 

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -13,6 +13,7 @@ data "template_file" "bastion_user_data" {
     unattended_upgrade_additional_configs = var.unattended_upgrade_additional_configs
     remove_root_access                    = var.remove_root_access
     additional_user_data                  = var.additional_user_data
+    additional_user_data_end              = var.additional_user_data_end
     # Join the rendered templates per additional user into a single string variable.
 
     additional_user_templates                                   = join("\n", data.template_file.additional_user.*.rendered)


### PR DESCRIPTION
This PR fixes issue https://github.com/FairwindsOps/terraform-bastion/pull/54#issuecomment-1014389472

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow end user to add commands in user_data after additional users are created.

### What changes did you make?
New input named additional_user_data_end.

### What alternative solution should we consider, if any?

