### PR TITLE
make userdata exit with code 0 when no reboot is required

### DIFF
--- a/aws/CHANGELOG.md
+++ b/aws/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [aws-unreleased]
 * Add input variable `additional_user_data_end` to execute commands after users creation.
+* Make userdata exit with code 0 when no reboot is required. This avoid cloud-init status to report an error.
 
 ## [aws-v3.0.0]
 * Introducting a breaking change by updating the terraform required_providers block to the format supported for terraform versions >=0.13

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -188,5 +188,8 @@ else
 fi
 
 info Rebooting, if required by any kernel updates earlier
-test -r /var/run/reboot-required && echo Reboot is required, doing that now... && shutdown -r now
+if test -r /var/run/reboot-required ; then
+  echo Reboot is required, doing that now...
+  shutdown -r now
+fi
 


### PR DESCRIPTION
This avoid cloud-init status to report an error.

This PR fixes issue #66

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?
Change the last command for UserData script to exit with code 0

### What alternative solution should we consider, if any?

