### PR TITLE
Fix iam.tf project variable type

### DIFF
--- a/gcp/iam.tf
+++ b/gcp/iam.tf
@@ -7,7 +7,7 @@ resource "google_service_account" "bastion" {
 
 resource "google_project_iam_member" "bastion_dns" {
   role = "roles/dns.admin"
-  project = data.google_project.project.number
+  project = data.google_project.project.id
   member = "serviceAccount:${google_service_account.bastion.email}"
 }
 


### PR DESCRIPTION
Corrects the project variable type in iam.tf.

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

### What changes did you make?
Use data.google_project.project.id in place of data.google_project.project.number

### What alternative solution should we consider, if any?

