### PR TITLE
Enable shielded nodes and confidential nodes GCP options

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -80,13 +80,13 @@ The following requirements are needed by this module:
 
 - terraform (>= 0.13)
 
-- google (>=2.0.0)
+- google (>=4.27.0)
 
 ### Providers
 
 The following providers are used by this module:
 
-- google (>=2.0.0)
+- google (>=4.27.0)
 
 - template
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -210,6 +210,30 @@ Type: `string`
 
 Default: `"n1-standard-1"`
 
+#### enable\_confidential\_compute
+
+Description: Enables confidential compute for the bastions vm instance.
+
+Type: `bool`
+
+Default: `"false"`
+
+#### enable\_secure\_boot
+
+Description: Enables secure boot for the bastions vm instance.
+
+Type: `bool`
+
+Default: `"false"`
+
+#### on\_host\_maintenance
+
+Description: How to handle host maintenance events for this VM. Must be one of MIGRATE or TERMINATE.
+
+Type: `string`
+
+Default: `"MIGRATE"`
+
 #### remove\_root\_access
 
 Description: Whether to remove root access from the ubuntu user. Set this to yes\|true\|1 to remove root access, or anything else to retain it.

--- a/gcp/inputs.tf
+++ b/gcp/inputs.tf
@@ -70,7 +70,7 @@ variable "enable_secure_boot" {
   default = false
 }
 
-variable "enable_confidential_nodes" {
+variable "enable_confidential_compute" {
   description = "Defines whether the instance should have confidential compute enabled."
   default = false
 }

--- a/gcp/inputs.tf
+++ b/gcp/inputs.tf
@@ -65,6 +65,16 @@ variable "machine_type" {
   default     = "n1-standard-1"
 }
 
+variable "enable_secure_boot" {
+  description = "Enables shielded instance secure boot which verifies the digital signature of all boot components, and halts the boot process if signature verification fails."
+  default = "false"
+}
+
+variable "enable_confidential_nodes" {
+  description = "Defines whether the instance should have confidential compute enabled."
+  default = "false"
+}
+
 variable "dns_zone_name" {
   description = "The name of the Google DNS zone for the bastion to add its host record. Specify the name of the managed zone, not the domain name."
 }

--- a/gcp/inputs.tf
+++ b/gcp/inputs.tf
@@ -75,6 +75,11 @@ variable "enable_confidential_compute" {
   default = false
 }
 
+variable "on_host_maintenance" {
+  description = "Sets the scheduling.onHostMaintenance behavior. Must be either MIGRATE or TERMINATE"
+  default = "MIGRATE"
+}
+
 variable "dns_zone_name" {
   description = "The name of the Google DNS zone for the bastion to add its host record. Specify the name of the managed zone, not the domain name."
 }

--- a/gcp/inputs.tf
+++ b/gcp/inputs.tf
@@ -67,12 +67,12 @@ variable "machine_type" {
 
 variable "enable_secure_boot" {
   description = "Enables shielded instance secure boot which verifies the digital signature of all boot components, and halts the boot process if signature verification fails."
-  default = "false"
+  default = false
 }
 
 variable "enable_confidential_nodes" {
   description = "Defines whether the instance should have confidential compute enabled."
-  default = "false"
+  default = false
 }
 
 variable "dns_zone_name" {

--- a/gcp/instance-template.tf
+++ b/gcp/instance-template.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance_template" "bastion" {
   }
 
   confidential_instance_config {
-    enable_confidential_config = var.enable_confidential_nodes
+    enable_confidential_compute = var.enable_confidential_nodes
   }
 
   service_account {

--- a/gcp/instance-template.tf
+++ b/gcp/instance-template.tf
@@ -48,6 +48,14 @@ resource "google_compute_instance_template" "bastion" {
     access_config {}
   }
 
+  shielded_instance_config {
+    enable_secure_boot = var.enable_secure_boot
+  }
+
+  confidential_instance_config {
+    enable_confidential_config = var.enable_confidential_nodes
+  }
+
   service_account {
     email = google_service_account.bastion.email
 

--- a/gcp/instance-template.tf
+++ b/gcp/instance-template.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance_template" "bastion" {
   }
 
   confidential_instance_config {
-    enable_confidential_compute = var.enable_confidential_nodes
+    enable_confidential_compute = var.enable_confidential_compute
   }
 
   service_account {

--- a/gcp/instance-template.tf
+++ b/gcp/instance-template.tf
@@ -33,7 +33,7 @@ resource "google_compute_instance_template" "bastion" {
 
   scheduling {
     automatic_restart   = true
-    on_host_maintenance = "MIGRATE"
+    on_host_maintenance = var.on_host_maintenance
   }
 
   disk {


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To enable the use of shielded_boot and confidential_compute for the bastion host, in gcp.

### What changes did you make?
Added `enable_secure_boot`, `enable_confidential_compute` and `on_host_maintenance` variables to allow enabling of all these features without changing the default behavior.

### What alternative solution should we consider, if any?
N/A
