### PR TITLE
Upgrade AWS root volume to gp3 (it's cheaper)

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -242,6 +242,14 @@ Type: `string`
 
 Default: `"true"`
 
+#### root\_volume\_type
+
+Description: The root volume type for the bastion instance.
+
+Type: `string`
+
+Default: `"gp3"`
+
 #### ssh\_cidr\_blocks
 
 Description: A list of CIDRs allowed to SSH to the bastion. Override the module default by specifying an empty list, []

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -22,8 +22,8 @@ resource "aws_autoscaling_group" "bastion" {
   dynamic "tag" {
     for_each = var.extra_asg_tags
     content {
-      key = tag.value["key"]
-      value = tag.value["value"]
+      key                 = tag.value["key"]
+      value               = tag.value["value"]
       propagate_at_launch = tag.value["propagate_at_launch"]
     }
   }

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -117,3 +117,9 @@ variable "extra_asg_tags" {
   description = "Extra tags for the bastion autoscaling group"
   default = []
 }
+
+variable "root_volume_type" {
+  type = string
+  description = "The root volume type for the bastion instance"
+  default = gp3
+}

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -113,13 +113,13 @@ variable "encrypt_root_volume" {
 }
 
 variable "extra_asg_tags" {
-  type = list
+  type        = list
   description = "Extra tags for the bastion autoscaling group"
-  default = []
+  default     = []
 }
 
 variable "root_volume_type" {
-  type = string
+  type        = string
   description = "The root volume type for the bastion instance"
-  default = gp3
+  default     = gp3
 }

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -121,5 +121,5 @@ variable "extra_asg_tags" {
 variable "root_volume_type" {
   type        = string
   description = "The root volume type for the bastion instance"
-  default     = gp3
+  default     = "gp3"
 }

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -39,6 +39,7 @@ resource "aws_launch_configuration" "bastion" {
 
   root_block_device {
     encrypted = var.encrypt_root_volume
+    volume_type = var.root_volume_type
   }
 
   lifecycle {

--- a/aws/launchconfig.tf
+++ b/aws/launchconfig.tf
@@ -35,10 +35,10 @@ resource "aws_launch_configuration" "bastion" {
   associate_public_ip_address = "true"
 
   user_data_base64 = base64gzip(data.template_file.bastion_user_data.rendered)
-  key_name = length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null
+  key_name         = length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null
 
   root_block_device {
-    encrypted = var.encrypt_root_volume
+    encrypted   = var.encrypt_root_volume
     volume_type = var.root_volume_type
   }
 


### PR DESCRIPTION
## Checklist
* [ x ] I have signed the CLA
* [ x ] I have updated/added any relevant documentation

## Description

### What changes did you make?

Made root volume type configurable for AWS bastion.

### What alternative solution should we consider, if any?

Not setting the default to gp3.
