### PR TITLE
Default bastion to 20.04

### DIFF
--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -2,7 +2,7 @@
 # replacing an unhealthy EC2 instance or recovering from an
 # availability zone failure.
 resource "aws_autoscaling_group" "bastion" {
-  # The Launch Configuration ID is part of the AUto Scalign Group name,
+  # The Launch Configuration ID is part of the Auto Scaling Group name,
   # to force the ASG and its EC2 to be recreated.
   name = "asg-${aws_launch_configuration.bastion.id}"
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -110,7 +110,7 @@ variable "ami_owner_id_govcloud" {
 
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
-  default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
 }
 
 variable "arn_prefix" {

--- a/gcp/compute-image.tf
+++ b/gcp/compute-image.tf
@@ -1,4 +1,4 @@
-# This gets the latest AMI for Ubuntu 18.04
+# This gets the latest AMI for Ubuntu 20.04
 data "google_compute_image" "ubuntu" {
   # Ref: https://cloud.google.com/compute/docs/images
   family  = var.image_family

--- a/gcp/inputs.tf
+++ b/gcp/inputs.tf
@@ -104,7 +104,7 @@ variable "ssh_cidr_blocks" {
 
 variable "image_family" {
   description = "The family for the compute image. This module has assumptions about the OS being Ubuntu."
-  default     = "ubuntu-1804-lts"
+  default     = "ubuntu-2004-lts"
 }
 
 variable "image_project" {


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
18.04 is EOL
### What changes did you make?
Select latest applicable 20.04 LTS release by default.
### What alternative solution should we consider, if any?

