### PR TITLE
Update aws bastion to use ubuntu 22.04 and launch templates

### DIFF
--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -39,6 +39,6 @@ resource "aws_autoscaling_group" "bastion" {
     ignore_changes = [load_balancers, target_group_arns]
   }
 
-  depends_on = aws_launch_template.bastion
+  depends_on = [aws_launch_template.bastion]
 }
 

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -2,8 +2,6 @@
 # replacing an unhealthy EC2 instance or recovering from an
 # availability zone failure.
 resource "aws_autoscaling_group" "bastion" {
-  # The Launch Configuration ID is part of the Auto Scaling Group name,
-  # to force the ASG and its EC2 to be recreated.
   name = "asg-${aws_launch_template.bastion.id}"
   launch_template {
     name = aws_launch_template.bastion.name
@@ -38,7 +36,5 @@ resource "aws_autoscaling_group" "bastion" {
     # Allow end user to attach a load balancer with `aws_autoscaling_attachment`.
     ignore_changes = [load_balancers, target_group_arns]
   }
-
-  depends_on = [aws_launch_template.bastion]
 }
 

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -4,9 +4,11 @@
 resource "aws_autoscaling_group" "bastion" {
   # The Launch Configuration ID is part of the Auto Scaling Group name,
   # to force the ASG and its EC2 to be recreated.
-  name = "asg-${aws_launch_configuration.bastion.id}"
-
-  launch_configuration = aws_launch_configuration.bastion.name
+  name = "asg-${aws_launch_template.bastion.id}"
+  launch_template {
+    name = aws_launch_template.bastion.name
+    version = "$Latest"
+  }
 
   min_size            = 1
   max_size            = 1
@@ -29,7 +31,7 @@ resource "aws_autoscaling_group" "bastion" {
   }
 
 
-  # THis needs to match the Launch Configuration.
+  # This needs to match the LaunchTemplate.
   lifecycle {
     create_before_destroy = true
 

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -7,7 +7,7 @@ resource "aws_autoscaling_group" "bastion" {
   name = "asg-${aws_launch_template.bastion.id}"
   launch_template {
     name = aws_launch_template.bastion.name
-    version = "$Latest"
+    version = aws_launch_template.bastion.latest_version
   }
 
   min_size            = 1

--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -38,5 +38,7 @@ resource "aws_autoscaling_group" "bastion" {
     # Allow end user to attach a load balancer with `aws_autoscaling_attachment`.
     ignore_changes = [load_balancers, target_group_arns]
   }
+
+  depends_on = aws_launch_template.bastion
 }
 

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -28,7 +28,7 @@ info Triggering a job using at, to sleep then run apt-get upgrade...
 echo "sleep 120 ; apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade" |at now
 
 info Installing packages needed on the bastion...
-apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install awscli python unattended-upgrades
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install awscli unattended-upgrades
 
 info The infra bucket is: ${infrastructure_bucket} and the S3 key is ${infrastructure_bucket_bastion_key}
 

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -28,8 +28,7 @@ info Triggering a job using at, to sleep then run apt-get upgrade...
 echo "sleep 120 ; apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade" |at now
 
 info Installing packages needed on the bastion...
-apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install unattended-upgrades
-snap install aws-cli --classic
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install awscli unattended-upgrades
 
 info The infra bucket is: ${infrastructure_bucket} and the S3 key is ${infrastructure_bucket_bastion_key}
 

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -28,7 +28,8 @@ info Triggering a job using at, to sleep then run apt-get upgrade...
 echo "sleep 120 ; apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade" |at now
 
 info Installing packages needed on the bastion...
-apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install awscli unattended-upgrades
+apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install unattended-upgrades
+snap install aws-cli --classic
 
 info The infra bucket is: ${infrastructure_bucket} and the S3 key is ${infrastructure_bucket_bastion_key}
 

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -99,7 +99,7 @@ variable "ami_owner_id_govcloud" {
 
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
-  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
 }
 
 variable "arn_prefix" {

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -99,7 +99,7 @@ variable "ami_owner_id_govcloud" {
 
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
-  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
 }
 
 variable "arn_prefix" {

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -99,7 +99,7 @@ variable "ami_owner_id_govcloud" {
 
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
-  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
 }
 
 variable "arn_prefix" {

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -99,7 +99,7 @@ variable "ami_owner_id_govcloud" {
 
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
-  default     = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
 }
 
 variable "arn_prefix" {

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -99,7 +99,7 @@ variable "ami_owner_id_govcloud" {
 
 variable "ami_filter_value" {
   description = "The filter path for the AMI."
-  default     = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
 }
 
 variable "arn_prefix" {

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -22,9 +22,6 @@ data "template_file" "bastion_user_data" {
 }
 
 resource "aws_launch_template" "bastion" {
-  # Generate a unique name for the Launch Configuration,
-  # so the Auto Scaling Group can be updated without conflict before destroying the previous Launch Configuration.
-  # Also see the related lifecycle block below.
   name_prefix = "${var.bastion_name}-"
 
   image_id      = data.aws_ami.ubuntu.id

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -38,6 +38,7 @@ resource "aws_launch_template" "bastion" {
 
   network_interfaces {
       associate_public_ip_address      = true
+      security_groups = [aws_security_group.bastion_ssh.id]
   }
 
   user_data = base64gzip(data.template_file.bastion_user_data.rendered)

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -34,8 +34,6 @@ resource "aws_launch_template" "bastion" {
     name = aws_iam_instance_profile.bastion.name
   }
 
-  vpc_security_group_ids             = [aws_security_group.bastion_ssh.id]
-
   network_interfaces {
       associate_public_ip_address      = true
       security_groups = [aws_security_group.bastion_ssh.id]

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -30,9 +30,15 @@ resource "aws_launch_template" "bastion" {
   image_id      = data.aws_ami.ubuntu.id
   instance_type = var.instance_type
 
-  iam_instance_profile               = aws_iam_instance_profile.bastion.name
+  iam_instance_profile {
+    name = aws_iam_instance_profile.bastion.name
+  }
+
   vpc_security_group_ids             = [aws_security_group.bastion_ssh.id]
-  associate_public_ip_address        = "true"
+
+  network_interfaces {
+      associate_public_ip_address      = true
+  }
 
   user_data = base64gzip(data.template_file.bastion_user_data.rendered)
   key_name         = length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -49,8 +49,6 @@ resource "aws_launch_template" "bastion" {
       volume_type = var.root_volume_type
     }
   }
-  
-  update_default_version = true
 
   lifecycle {
     create_before_destroy = true

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -49,12 +49,14 @@ resource "aws_launch_template" "bastion" {
       volume_type = var.root_volume_type
     }
   }
+  
+  update_default_version = true
 
   lifecycle {
     create_before_destroy = true
 
-    # DO not recreate the Launch Configuration if a newer AMI becomes available.
-    # `terrform taint` the Launch Configuration resource to force it to be recreated.
+    # DO not recreate the Launch Template if a newer AMI becomes available.
+    # `terrform taint` the Launch Template resource to force it to be recreated.
     # In the future we may want to also include user-data in this list.
     ignore_changes = [image_id]
   }


### PR DESCRIPTION
This PR updates the AWS bastion to use Ubuntu 22.04 AMIs by default, and changes from using a launch configuration to a launch template.

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

To update the Bastion to use launch templates, as well as the Ubuntu 22.04 AMI.

