### PR TITLE
imdsv2 configuration

### DIFF
--- a/aws/auto-scaling.tf
+++ b/aws/auto-scaling.tf
@@ -28,6 +28,10 @@ resource "aws_autoscaling_group" "bastion" {
     }
   }
 
+  instance_refresh {
+    strategy = "Rolling"
+  }
+
 
   # This needs to match the LaunchTemplate.
   lifecycle {

--- a/aws/bastion-userdata.tmpl
+++ b/aws/bastion-userdata.tmpl
@@ -6,9 +6,11 @@ function info {
   echo "user-data: $@"
 }
 
+# Getting IMDSv2 token
+TOKEN=`curl -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 600"`
 
 info Getting the AWS availability zone and region
-EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+EC2_AVAIL_ZONE=`curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone`
 EC2_REGION=`echo "$${EC2_AVAIL_ZONE:0:$${#EC2_AVAIL_ZONE}-1}"`
 info The EC2 region is: $${EC2_REGION}
 info The EC2 availability zone is: $${EC2_AVAIL_ZONE}
@@ -84,7 +86,7 @@ rm -f cloudwatch-agent.conf cloudwatch-agent.deb
 
 info Setting up DNS registration on boot
 info Downloading the cli53 tool
-curl -Lo /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.13/cli53-linux-amd64
+curl -Lo /usr/local/bin/cli53 https://github.com/barnybug/cli53/releases/download/0.8.22/cli53-linux-amd64
 chmod +x /usr/local/bin/cli53
 info Creating the /usr/local/bin/register-dns script using route53 zone ID ${zone_id}. . .
 cat <<'EOF' >/usr/local/bin/register-dns
@@ -92,7 +94,8 @@ cat <<'EOF' >/usr/local/bin/register-dns
 
 zone_id="${zone_id}"
 bastion_name="${bastion_name}"
-public_ip=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+TOKEN=`curl -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 600"`
+public_ip=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
 zone_name=$(cli53 list -f csv |grep ${zone_id}|cut -d, -f2)
 
 echo $0 - registering $${bastion_name}.$${zone_name} to IP $${public_ip} using zone ID $${zone_id}...

--- a/aws/inputs.tf
+++ b/aws/inputs.tf
@@ -53,7 +53,7 @@ variable "additional_user_data" {
 
 variable "instance_type" {
   description = "The EC2 instance type of the bastion."
-  default     = "t2.micro"
+  default     = "t3.micro"
 }
 
 variable "route53_zone_id" {

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -36,6 +36,10 @@ resource "aws_launch_template" "bastion" {
       security_groups = [aws_security_group.bastion_ssh.id]
   }
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   user_data = base64gzip(data.template_file.bastion_user_data.rendered)
   key_name         = length(aws_key_pair.bastion) > 0 ? aws_key_pair.bastion[0].id : null
 


### PR DESCRIPTION
This PR fixes #

## Checklist
* [X] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

The aws terraform provider now defaults EC2 instances to use imdsv2 unless specified in the config. These changes allow for imdsv2 by using tokens for calls to the metadata service.

### What changes did you make?

- Updated the userdata template to get and use tokens for curl calls to the metadata service
- Updated the `cli53` tool to the latest version
- Added an `instance_refresh` block to the autoscaling group template. The VMs were not always being replaced without this block.

### What alternative solution should we consider, if any?

`cli53` has been updated the latest version, `0.8.22`. The tool hasn't been updated since February 2023, so we may want to use a different mechanism to update the bastion's A record, like the aws cli.