### PR TITLE
Swtich to aws_s3_object from deprecated aws_s3_bucket_object

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -115,7 +115,7 @@ The following resources are used by this module:
 - [aws_iam_role_policy.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) (resource)
 - [aws_key_pair.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) (resource)
 - [aws_launch_template.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) (resource)
-- [aws_s3_bucket_object.additional-external-users-script](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) (resource)
+- [aws_s3_object.additional-external-users-script](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) (resource)
 - [aws_security_group.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) (resource)
 - [aws_security_group_rule.bastion_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)
 - [aws_security_group_rule.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) (resource)

--- a/aws/additional_external_user.tf
+++ b/aws/additional_external_user.tf
@@ -47,7 +47,7 @@ locals {
   additional-external-users-script-md5     = md5(local.additional-external-users-script-content)
 }
 
-resource "aws_s3_bucket_object" "additional-external-users-script" {
+resource "aws_s3_object" "additional-external-users-script" {
   bucket  = local.infrastructure_bucket.id
   key     = "${var.infrastructure_bucket_bastion_key}/additional-external-users"
   content = local.additional-external-users-script-content

--- a/aws/launchtemplate.tf
+++ b/aws/launchtemplate.tf
@@ -16,7 +16,7 @@ data "template_file" "bastion_user_data" {
     # Join the rendered templates per additional user into a single string variable.
 
     additional_user_templates                                   = join("\n", data.template_file.additional_user.*.rendered)
-    infrastructure_bucket_additional_external_users_script_etag = aws_s3_bucket_object.additional-external-users-script.etag
+    infrastructure_bucket_additional_external_users_script_etag = aws_s3_object.additional-external-users-script.etag
     additional-external-users-script-md5                        = local.additional-external-users-script-md5
   }
 }


### PR DESCRIPTION
This PR fixes #85 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Migrate from the deprecated `aws_s3_bucket_object` to the new `aws_s3_object` resource.

### What changes did you make?
* Replaced `aws_s3_bucket_object.additional-external-users-script` with `aws_s3_object.additional-external-users-script` in `aws/additional_external_user.tf`
* Replaced references the above in `aws/launchtemplate.tf`
* Update Terraform docs in `README.md`

### What alternative solution should we consider, if any?
N/A
